### PR TITLE
Laravel 8 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^5.8 || ^6 || ^7",
+        "laravel/framework": "^5.8 || ^6 || ^7 || ^8",
         "laravel/passport": "^7 || ^8 || ^9",
         "mews/purifier": "^3.1",
         "cviebrock/eloquent-sluggable": "^4 || ^6 || ^7",


### PR DESCRIPTION
I just attempted to install Chatter in a project and I got an error (see #30), where Chatter is not compatible with Laravel 8.